### PR TITLE
Add Answer Feature

### DIFF
--- a/app/controllers/answers.rb
+++ b/app/controllers/answers.rb
@@ -1,4 +1,27 @@
+
+
+get '/answers/new' do
+  # user has requested to add an answer
+  # if user is logged in, return a "new answer" form (partial)
+  if request.xhr?
+    # ajax request
+    # do not allow user to answer question unless he or she is logged in
+    if session[:user_id]
+      # user is logged in; okay to return new answer form
+      erb :"/answers/_new-answer-form", layout: false
+    else
+      # TEAM JPEG - I need help figuring out how to display this error message
+      @_add_answer_error = "To post an answer, please log in."
+    end
+  else
+    # not an ajax request
+  end
+end
+
 post '/answers/new' do
+  # user has typed in a new answer and has submitted it
+  # if user is logged in, save the answer and display it 
+  # at the end of the current answers
   puts 'in answers.rb controller, /answers/new POST was hit'
   # create a new answer object and save to database
   puts "params to follow in POST /answers/new"
@@ -6,34 +29,34 @@ post '/answers/new' do
   if request.xhr?
     # ajax request
     puts 'this is a POST ajax request'
+    puts 'request to follow:'
+    p request
+    puts 'params[:answer_text] to follow'
+    p params[:answer_text]
+    puts 'session[:user_id] to follow'
+    p session[:user_id]
+    puts 'session[:question_id] to follow'
+    p session[:question_id]
+    new_answer = Answer.new({answer_text: params[:answer_text]} )
+    this_user=User.find(session[:user_id])
+    puts 'this user to follow'
+    p this_user
+    this_question = Question.find(session[:question_id])
+    p this_question
+    this_user.answers << new_answer
+    this_question.answers << new_answer
+    puts "JUSt UPDATED foreign key to reflect user and question"
+    answer_object=Answer.find(new_answer.id)
+    puts 'answer object to follow'
+    p answer_object
+    # puts 'about to print new_answer that was just created'
+    # puts 'answer text is: ' + new_answer.answer_text
+    # puts 'question id is: ' + new_answer.question_id.to_s
+    # puts 'user id is: ' + new_answer.user_id.to_s
+    # # return a partial that has new answer information in it
+    erb :"/answers/_answer-item", layout: false, locals: {answer_text: params[:answer_text]}  
   else
+    # not an AJAX request
     puts 'this is NOT an ajax request - post'
   end
-  puts 'request to follow:'
-  p request
-  new_answer = Answer.create(params[:answer])
-  puts 'about to print new_answer that was just created'
-  puts 'answer text is: ' + new_answer.answer_text
-  puts 'question id is: ' + new_answer.question_id.to_s
-  puts 'user id is: ' + new_answer.user_id.to_s
-  # return a partial that has new answer information in it
-  erb :"/answers/_answer-item", layout: false, locals: {answer: new_answer}  
-end
-
-get '/answers/new' do
-  # return new answer form (partial)
-  puts 
-  puts
-  puts 'in answers.rb controller,/answers/new GET was hit'
-  puts 'we need to return the partial'
-  if request.xhr?
-    # ajax request
-    puts 'this is an ajax request GET'
-  else
-    puts 'this is NOT an ajax request - get'
-  end
-  puts 'request to follow:'
-  p request
-  # do not include layout with html we are returning
-  erb :"/answers/_new-answer-form", layout: false
 end

--- a/app/controllers/answers.rb
+++ b/app/controllers/answers.rb
@@ -5,11 +5,11 @@ get '/answers/new' do
   # if user is logged in, return a "new answer" form (partial)
   if request.xhr?
     # ajax request
-    # do not allow user to answer question unless he or she is logged in
     if session[:user_id]
       # user is logged in; okay to return new answer form
       erb :"/answers/_new-answer-form", layout: false
     else
+      # user is not logged in; posting an answer is not permitted
       # TEAM JPEG - I need help figuring out how to display this error message
       @_add_answer_error = "To post an answer, please log in."
     end
@@ -19,44 +19,23 @@ get '/answers/new' do
 end
 
 post '/answers/new' do
-  # user has typed in a new answer and has submitted it
+  # user has typed in a new answer and has submitted it;
   # if user is logged in, save the answer and display it 
   # at the end of the current answers
-  puts 'in answers.rb controller, /answers/new POST was hit'
-  # create a new answer object and save to database
-  puts "params to follow in POST /answers/new"
-  p params
   if request.xhr?
     # ajax request
-    puts 'this is a POST ajax request'
-    puts 'request to follow:'
-    p request
-    puts 'params[:answer_text] to follow'
-    p params[:answer_text]
-    puts 'session[:user_id] to follow'
-    p session[:user_id]
-    puts 'session[:question_id] to follow'
-    p session[:question_id]
-    new_answer = Answer.new({answer_text: params[:answer_text]} )
-    this_user=User.find(session[:user_id])
-    puts 'this user to follow'
-    p this_user
-    this_question = Question.find(session[:question_id])
-    p this_question
-    this_user.answers << new_answer
-    this_question.answers << new_answer
-    puts "JUSt UPDATED foreign key to reflect user and question"
-    answer_object=Answer.find(new_answer.id)
-    puts 'answer object to follow'
-    p answer_object
-    # puts 'about to print new_answer that was just created'
-    # puts 'answer text is: ' + new_answer.answer_text
-    # puts 'question id is: ' + new_answer.question_id.to_s
-    # puts 'user id is: ' + new_answer.user_id.to_s
-    # # return a partial that has new answer information in it
-    erb :"/answers/_answer-item", layout: false, locals: {answer_text: params[:answer_text]}  
+    if session[:user_id]
+      new_answer = Answer.new({answer_text: params[:answer_text]} )
+      User.find(session[:user_id]).answers << new_answer
+      Question.find(session[:question_id]).answers << new_answer
+      # # return a partial that has new answer information in it
+      erb :"/answers/_answer-item", layout: false, locals: {answer_text: params[:answer_text]}  
+    else
+      # user is not logged in; posting an answer is not permitted
+      # TEAM JPEG - I need help figuring out how to display this error message
+      @_add_answer_error = "To post an answer, please log in."
+    end
   else
     # not an AJAX request
-    puts 'this is NOT an ajax request - post'
   end
 end

--- a/app/controllers/answers.rb
+++ b/app/controllers/answers.rb
@@ -1,0 +1,39 @@
+post '/answers/new' do
+  puts 'in answers.rb controller, /answers/new POST was hit'
+  # create a new answer object and save to database
+  puts "params to follow in POST /answers/new"
+  p params
+  if request.xhr?
+    # ajax request
+    puts 'this is a POST ajax request'
+  else
+    puts 'this is NOT an ajax request - post'
+  end
+  puts 'request to follow:'
+  p request
+  new_answer = Answer.create(params[:answer])
+  puts 'about to print new_answer that was just created'
+  puts 'answer text is: ' + new_answer.answer_text
+  puts 'question id is: ' + new_answer.question_id.to_s
+  puts 'user id is: ' + new_answer.user_id.to_s
+  # return a partial that has new answer information in it
+  erb :"/answers/_answer-item", layout: false, locals: {answer: new_answer}  
+end
+
+get '/answers/new' do
+  # return new answer form (partial)
+  puts 
+  puts
+  puts 'in answers.rb controller,/answers/new GET was hit'
+  puts 'we need to return the partial'
+  if request.xhr?
+    # ajax request
+    puts 'this is an ajax request GET'
+  else
+    puts 'this is NOT an ajax request - get'
+  end
+  puts 'request to follow:'
+  p request
+  # do not include layout with html we are returning
+  erb :"/answers/_new-answer-form", layout: false
+end

--- a/app/controllers/questions.rb
+++ b/app/controllers/questions.rb
@@ -11,12 +11,15 @@ end
 
 get '/questions/:id' do
   @question = Question.find(params[:id])
+  session[:question_id] = @question.id
+  puts 'in questions.rb about to display this question, SESSION TO FOLLOW'
+  p session
   erb :"/questions/show"
 end
 
 post '/questions' do
   question_asked = params[:question]
-  poster_id = session[:user][:id]
+  poster_id = session[:user_id]
   new_question = Question.create(question_text: question_asked, user_id: poster_id)
   redirect to "/questions/#{new_question.id}"
 end

--- a/app/controllers/questions.rb
+++ b/app/controllers/questions.rb
@@ -1,3 +1,5 @@
+
+
 get '/questions' do
   @questions = Question.all
   erb :'/questions/index'

--- a/app/controllers/questions.rb
+++ b/app/controllers/questions.rb
@@ -12,8 +12,6 @@ end
 get '/questions/:id' do
   @question = Question.find(params[:id])
   session[:question_id] = @question.id
-  puts 'in questions.rb about to display this question, SESSION TO FOLLOW'
-  p session
   erb :"/questions/show"
 end
 

--- a/app/controllers/sessions.rb
+++ b/app/controllers/sessions.rb
@@ -1,14 +1,21 @@
+
+
+
 delete '/sessions' do
   session.destroy
   redirect '/'
 end
+
 
 post '/sessions' do
   email = params[:user][:email]
   user = User.find_by(email: email)
   if user
     if user.authenticate(email, params[:user][:password])
-      session[:user] = user
+      # Hello, TEAM JPEG! I changed the session key from user to user_id
+      # because I was running into issues with the cookie being too large
+      # session[:user] = user
+      session[:user_id] = user.id
       redirect '/'
     else
       @error = "Invalid password."
@@ -18,4 +25,9 @@ post '/sessions' do
     @error = "Invalid email."
     erb :'/index'
   end
+end
+
+#helper to allow us to see what is in session
+get '/session-viewer' do
+  session.inspect
 end

--- a/app/controllers/sessions.rb
+++ b/app/controllers/sessions.rb
@@ -1,6 +1,4 @@
 
-
-
 delete '/sessions' do
   session.destroy
   redirect '/'

--- a/app/controllers/users.rb
+++ b/app/controllers/users.rb
@@ -4,7 +4,10 @@ post '/users' do
   user = User.new(params[:user])
   user.save
   if user.persisted?
-    session[:user] = user
+    # Hello, TEAM JPEG! I changed the session key from user to user_id
+    # because I was running into issues with the cookie being too large
+    # session[:user] = user
+    session[:user_id] = user.id
     redirect '/'
   else
     erb :"_registration-form"

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,9 +1,9 @@
 class Answer < ActiveRecord::Base
   has_many :comments, as: :commentable
-  has_many :votes, as: :votable
+  has_many :votes
   belongs_to :user
   belongs_to :question
 
-  validates_presence_of :user
+  validates_presence_of :user 
   validates_presence_of :question
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,9 +1,8 @@
 class Comment < ActiveRecord::Base
   belongs_to :commentable, polymorphic: true
   belongs_to :user
+  has_many :self_comments, as: :commentable, class_name: "Comment" 
 
-  has_many :self_comments, as: :commentable, class_name: "Comment"
-  has_many :votes, as: :votable
 
   validates_presence_of :user
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,7 +1,6 @@
 class Question < ActiveRecord::Base
   has_many :comments, as: :commentable
   has_many :answers
-  has_many :votes, as: :votable
   belongs_to :user
 
   validates_presence_of :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,18 +1,15 @@
-enable :sessions
 require 'bcrypt'
 
 class User < ActiveRecord::Base
-  include BCrypt
-
+  
   has_many :questions
   has_many :answers
   has_many :votes
   has_many :comments
 
   validates :email, presence: true, uniqueness: true
-  validates :password_hash, presence: true
-  validates :name, presence: true
 
+  include BCrypt
   def password
     @password ||= Password.new(password_hash)
   end
@@ -22,8 +19,4 @@ class User < ActiveRecord::Base
     self.password_hash = @password
   end
 
-  def authenticate(email, password)
-    user = User.find_by(email: email)
-    user.password == password
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,9 @@ class User < ActiveRecord::Base
     self.password_hash = @password
   end
 
+  def authenticate(email, password)
+    user = User.find_by(email: email)
+    user.password == password
+  end
+
 end

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -1,9 +1,6 @@
 class Vote < ActiveRecord::Base
   belongs_to :user
   belongs_to :answer
-  belongs_to :question
-  belongs_to :comment
-  belongs_to :votable, polymorphic: true
 
   validates_presence_of :user
 end

--- a/app/views/answers/_answer-item.erb
+++ b/app/views/answers/_answer-item.erb
@@ -1,4 +1,4 @@
 <li class="answer">
-  <%= answer.answer_text %>
+  <%= answer_text %>
   <h4>Comments</h4>
 </li>

--- a/app/views/answers/_answer-item.erb
+++ b/app/views/answers/_answer-item.erb
@@ -1,0 +1,4 @@
+<li class="answer">
+  <%= answer.answer_text %>
+  <h4>Comments</h4>
+</li>

--- a/app/views/answers/_new-answer-form.erb
+++ b/app/views/answers/_new-answer-form.erb
@@ -1,5 +1,5 @@
   <form class="inline" id="new-answer-form" action="/../../answers/new" method="POST">
-    <input type="text" name="answer_text" placeholder="Enter answer here">
+    <input id='new-answer' type="text" name="answer_text" placeholder="Enter answer here">
     <input type="submit" value="Post Answer">
   </form>
 

--- a/app/views/answers/_new-answer-form.erb
+++ b/app/views/answers/_new-answer-form.erb
@@ -1,0 +1,7 @@
+  <form class="inline" id="new-answer-form" action="/../../answers/new" method="POST">
+    <input type="text" name="answer_text" placeholder="Enter answer here">
+    <input type="submit" value="Post Answer">
+  </form>
+
+
+

--- a/app/views/answers/_new-answer-form.erb
+++ b/app/views/answers/_new-answer-form.erb
@@ -1,7 +1,10 @@
-  <form class="inline" id="new-answer-form" action="/../../answers/new" method="POST">
-    <input id='new-answer' type="text" name="answer_text" placeholder="Enter answer here">
-    <input type="submit" value="Post Answer">
-  </form>
+    <form class="inline" id="new-answer-form" action="/../../answers/new" method="POST">
+      <input id='new-answer' type="text" name="answer_text" placeholder="Enter answer here">
+      <input type="submit" value="Post Answer">
+    </form>
+
+
+  
 
 
 

--- a/app/views/answers/new.erb
+++ b/app/views/answers/new.erb
@@ -1,0 +1,7 @@
+<br>
+<br>
+
+<div>
+  <%= erb :'answers/_new-answer-form' %>
+</div>
+

--- a/app/views/questions/show.erb
+++ b/app/views/questions/show.erb
@@ -24,6 +24,11 @@
     <% end %>
     </ul>
   </div>
+
+<button id='add-answer-button' type="button">Add Answer</button>
+<div id='new-answer-container'
   <!-- FORM TO ANSWER QUESTION
-       WHEN CLICKED, AJAXIFICATES A FORM TO APPEAR BELOW -->
+    
+</div>
+</form>
 </div>

--- a/db/migrate/20170406202730_create_votes.rb
+++ b/db/migrate/20170406202730_create_votes.rb
@@ -2,8 +2,7 @@ class CreateVotes < ActiveRecord::Migration
   def change
     create_table :votes do |t|
       t.integer :user_id, null: false
-      t.integer :votable_id, null: false
-      t.string :votable_type, null: false
+      t.integer :answer_id, null: false
       t.string :up_or_down, null: false
 
       t.timestamps null: false

--- a/db/migrate/20170406202754_create_comments.rb
+++ b/db/migrate/20170406202754_create_comments.rb
@@ -3,14 +3,14 @@ class CreateComments < ActiveRecord::Migration
     create_table :comments do |t|
       t.string :comment_text, null: false
       t.integer :user_id, null: false
-      # t.references :commentable, polymorphic: true, index: true
       t.integer :commentable_id, null: false
-      t.string :commentable_type, null: false
+      t.string :commentable_type, null:false
 
       t.timestamps null: false
     end
   end
- end
+  # add index :comments, [commentable_type, :commentable_id]
+end
 
 
 

--- a/db/migrate/20170409095452_add_index_to_table_votes.rb
+++ b/db/migrate/20170409095452_add_index_to_table_votes.rb
@@ -1,0 +1,5 @@
+class AddIndexToTableVotes < ActiveRecord::Migration
+  def change
+    add_index :votes, [:votable_type, :votable_id]
+  end
+end

--- a/public/js/application.js
+++ b/public/js/application.js
@@ -1,40 +1,33 @@
 $(document).ready(function() {
-// when "add answer" button is clicked, prevent default behavior
-// and get new answer form from server
-$('#add-answer-button').on('click',function(origEvent) {
-  console.log('add answer button was clicked');
-  origEvent.preventDefault();
-  $.ajax ({
-    url: '/../../answers/new',
-    type: 'GET'
-  }).done(function(response) {
-    console.log('in DONE response in js file add answer button click');
-    console.log('response value to follow:');
-    console.log(response);
-    $('#new-answer-container').append(response);
-  })
-})
 
-// when new answer is submitted, send ajax post with entered data to server
-// when response is returned, destroy new answer form and post button
-// and display new answer
-$('#new-answer-container').submit(function(origEvent) {
- origEvent.preventDefault();
- new_answer = $('#new-answer').val()
-  console.log('submit button on new answer form was clicked');
-  console.log('new answer entered is ' + new_answer)
-  $.ajax({
-    url: '/../../answers/new',
-    type: 'POST',
-    data: { answer_text: new_answer }
-  }).done(function(response) {
-    console.log('in response in js file submit new answer button click');
-    console.log('response value to follow:');
-    console.log(response);
-    // insert partial question answer 
-    $('#answers-container').append(response);
+  // when "add answer" button is clicked, prevent default behavior
+  // and display "new answer" form
+  $('#add-answer-button').on('click',function(origEvent) {
+    console.log('add answer button was clicked');
+    origEvent.preventDefault();
+    $.ajax ({
+      url: '/../../answers/new',
+      type: 'GET'
+    }).done(function(response) {
+      $('#new-answer-container').append(response);
+    })
+  })
+
+  // when new answer is submitted, send ajax post with entered data to server
+  // when response is returned, destroy new answer form and post button
+  // and display new answer
+  $('#new-answer-container').submit(function(origEvent) {
+    origEvent.preventDefault();
+    new_answer = $('#new-answer').val()
+    $.ajax({
+      url: '/../../answers/new',
+      type: 'POST',
+      data: { answer_text: new_answer }
+    }).done(function(response) {
+      // insert partial showing new answer 
+      $('#answers-container').append(response);
+    });
   });
-});
 
 });
 

--- a/public/js/application.js
+++ b/public/js/application.js
@@ -20,11 +20,13 @@ $('#add-answer-button').on('click',function(origEvent) {
 // and display new answer
 $('#new-answer-container').submit(function(origEvent) {
  origEvent.preventDefault();
- console.log('submit button on new answer form was clicked');
-    $.ajax({
+ new_answer = $('#new-answer').val()
+  console.log('submit button on new answer form was clicked');
+  console.log('new answer entered is ' + new_answer)
+  $.ajax({
     url: '/../../answers/new',
     type: 'POST',
-    data: { answer: {question_id: 1, user_id: 1, answer_text: 'hi'}}
+    data: { answer_text: new_answer }
   }).done(function(response) {
     console.log('in response in js file submit new answer button click');
     console.log('response value to follow:');

--- a/public/js/application.js
+++ b/public/js/application.js
@@ -14,7 +14,7 @@ $(document).ready(function() {
   })
 
   // when new answer is submitted, send ajax post with entered data to server
-  // when response is returned, destroy new answer form and post button
+  // when response is returned, clear new answer form/post button
   // and display new answer
   $('#new-answer-container').submit(function(origEvent) {
     origEvent.preventDefault();
@@ -26,6 +26,8 @@ $(document).ready(function() {
     }).done(function(response) {
       // insert partial showing new answer 
       $('#answers-container').append(response);
+      // clear new answer form
+      $('#new-answer-container').empty()
     });
   });
 

--- a/public/js/application.js
+++ b/public/js/application.js
@@ -1,2 +1,39 @@
 $(document).ready(function() {
+// when "add answer" button is clicked, prevent default behavior
+// and get new answer form from server
+$('#add-answer-button').on('click',function(origEvent) {
+  console.log('add answer button was clicked');
+  origEvent.preventDefault();
+  $.ajax ({
+    url: '/../../answers/new',
+    type: 'GET'
+  }).done(function(response) {
+    console.log('in DONE response in js file add answer button click');
+    console.log('response value to follow:');
+    console.log(response);
+    $('#new-answer-container').append(response);
+  })
+})
+
+// when new answer is submitted, send ajax post with entered data to server
+// when response is returned, destroy new answer form and post button
+// and display new answer
+$('#new-answer-container').submit(function(origEvent) {
+ origEvent.preventDefault();
+ console.log('submit button on new answer form was clicked');
+    $.ajax({
+    url: '/../../answers/new',
+    type: 'POST',
+    data: { answer: {question_id: 1, user_id: 1, answer_text: 'hi'}}
+  }).done(function(response) {
+    console.log('in response in js file submit new answer button click');
+    console.log('response value to follow:');
+    console.log(response);
+    // insert partial question answer 
+    $('#answers-container').append(response);
+  });
 });
+
+});
+
+


### PR DESCRIPTION
@Eitan-G @pjc5108 @gracenoh153 
Hi, Team JPEG! Please review and merge. I checked out master prior to pushing, and it said my branch was up to date with the master, so I didn't do a git pull prior to pushing this feature branch.

This feature branch adds the "add answer" functionality. It's not pretty, but it works. I would love to get some help today figuring out the best way to display an error message when a non-logged in user attempts to add an answer.

I added a “question_id” key to the session so that the “add answer” code would know which question a new answer belongs to. At first, I tried adding a "question" key to the session (similar to the "user" key that was already there which stored the whole user object, not just the user_id). I got an error saying that the cookie was too long. Looking back on my notes, I see that in the examples, they set “user_id” in the session, not the full user object. I stored only the “question_id” field in the session, and I also changed the “user” session key to "user_id" and modified the login and register code to reflect this change. I hope you agree (if not we can handle at merge time). If this change stands, we’ll need to check for “session[:user_id]” instead of “session[:user]” when making sure a user is logged in before adding comments, votes, etc.

One more thing: I added a session-viewer helper to the sessions controller. If you ever want to inspect a session, you can type ‘localhost:9393/session-viewer’ in the address bar.